### PR TITLE
Add pcr7data to initrd

### DIFF
--- a/creating-signdata.txt
+++ b/creating-signdata.txt
@@ -1,0 +1,132 @@
+# Steps to create a showpcrs.iso
+
+## enter the keyset directory.  It should already have a bootkit/
+```
+cd .local/share/machine/trust/keys/snakeoil
+```
+
+## fetch the showpcrs binary
+```
+wget https://github.com/project-machine/showpcr/releases/download/v1.0.0/showpcrs.efi
+```
+
+## create the three signed showpcrs
+```
+sbsign --key uki-limited/privkey.pem --cert uki-limited/cert.pem \
+   --output bootkit/showpcrs-limited.efi bootkit/showpcrs.efi
+sbsign --key uki-production/privkey.pem --cert uki-production/cert.pem \
+   --output bootkit/showpcrs-production.efi bootkit/showpcrs.efi
+sbsign --key uki-tpm/privkey.pem --cert uki-tpm/cert.pem \
+   --output bootkit/showpcrs-tpm.efi bootkit/showpcrs.efi
+```
+
+## Create and populate an EFI directory
+```
+truncate -s 40M efi.vfat
+mkfs.vfat -v -F32 -s1 -n esp -S512 efi.vfat
+for base in showpcrs-tpm.efi showpcrs-production.efi showpcrs-limited.efi shim.efi; do
+	mcopy -i efi.vfat bootkit/$base ::$base
+done
+
+rm -rf ISO
+mkdir ISO
+mv efi.vfat ISO/
+```
+
+## Create the bootable ISO
+```
+xorriso -compliance iso_9660_level=3 \
+  -as mkisofs \
+  -eltorito-alt-boot -no-emul-boot -isohybrid-gpt-basdat \
+  -e efi.vfat \
+  -V showpcrs \
+  -o showpcrs.iso \
+  ISO
+```
+
+## Create a machine to boot with this ISO:
+```
+cat > showpcrs-vm.yaml << EOF
+name: showpcrs
+type: kvm
+ephemeral: false
+description: A VM for getting signdata info
+config:
+  name: showpcrs
+  uefi: true
+  nics: []
+  uefi-vars: /home/serge/.local/share/machine/trust/keys/snakeoil/bootkit/ovmf-vars.fd
+  cdrom: /home/serge/.local/share/machine/trust/keys/snakeoil/showpcrs.iso
+  boot: cdrom
+  disks: []
+  tpm: true
+  gui: true
+  serial: true
+  tpm-version: 2.0
+  secure-boot: true
+EOF
+machine init < showpcrs-vm.yaml
+```
+
+
+## Gather output
+
+Boot the VM three times.  Each time run a different showpcr.efi
+under the shim, and copy/paste the output into a file:
+
+```
+machine start showpcrs
+machine console showpcrs
+> fs0:
+> .\shim.efi .\showpcrs-limited.efi
+> reset -s
+# [ machine shuts down ]
+machine start showpcrs
+machine console showpcrs
+> fs0:
+> .\shim.efi .\showpcrs-production.efi
+> reset -s
+# [ machine shuts down ]
+machine start showpcrs
+machine console showpcrs
+> fs0:
+> .\shim.efi .\showpcrs-tpm.efi
+> reset -s
+```
+
+The output of each run will look like:
+
+```
+8A 03 88 B1 CC CD A7 27 65 41 E1 AE 19 9C 45 64 04 01 C3 55 C1 A2 68 EB 1D 98 DF 46 39 77 F7 1E
+```
+
+To convert this to a tpm_X.bin, use the following awk script:
+
+```
+# Run with LC_CTYPE=C
+BEGIN { RS=" "; }
+/PCR07/ { next; }
+/^$/ { next; }
+{ printf("%c", strtonum("0x" $0)) }
+```
+
+Make sure to set LC_CTYPE=C, or the binary file will be wrong:
+
+```
+LC_CTYPE=C awk -f pcr7.awk console_output > pcr7.bin
+```
+
+Put each into its own file.
+
+Finally, you can use trust to create the signdata:
+```
+mkdir -p tpm-policy
+trust tpm-policy-gen \
+  --passwd-policy-file tpm-policy/passwd.policy \
+  --luks-policy-file tpm-policy/luks.policy \
+  --passwd-pcr7-file pcr7.passwd \
+  --luks-pcr7-file pcr7.luks \
+  --policy-version 1 \
+  --passwd-pubkey-file tpmpol-admin/cert.pem \
+  --luks-pubkey-file tpmpol-luks/cert.pem
+```

--- a/live/README.md
+++ b/live/README.md
@@ -66,11 +66,17 @@
 
 * Build a provisioning ISO
 
+Note that all of this is meant to be done automatically as you
+create a VM.  These manual steps are temporary.
+
   ```
   $ stacker build -f provision-stacker.yaml --layer-type=squashfs
   $ ./build-livecd-rfs --layer oci:oci:provision-rootfs-squashfs \
      --output provision.iso
-  $ mkdir SUDI; cp ~/.local/share/machine/trust/keys/snakeoil/manifest/default/sudi/XXX/* SUDI/
+  $ # If needed, create a SUDI keypair for the VM, for instance:
+  $ trust sudi add snakeoil default SN001
+  $ # Create a vfat file with the provisioning info
+  $ mkdir SUDI; cp ~/.local/share/machine/trust/keys/snakeoil/manifest/default/sudi/SN001/* SUDI/
   $ truncate -s 20M sudi.vfat
   $ mkfs.vfat -n trust-data sudi.vfat
   $ mcopy -i sudi.vfat SUDI/cert.pem ::cert.pem

--- a/live/README.md
+++ b/live/README.md
@@ -16,7 +16,8 @@
  * build the rootfs
  
     ```
-    stacker build --layer-type=squashfs
+    stacker build --layer-type=squashfs \
+      --substitute ROOTFS_VERSION=0.0.5.230327-squashfs
     ```
 
    * Note: I  seem to be hitting a bug with this, where it fails to build the second time.
@@ -70,7 +71,8 @@ Note that all of this is meant to be done automatically as you
 create a VM.  These manual steps are temporary.
 
   ```
-  $ stacker build -f provision-stacker.yaml --layer-type=squashfs
+  $ stacker build -f provision-stacker.yaml --layer-type=squashfs \
+      --substitute ROOTFS_VERSION=0.0.5.230327-squashfs
   $ ./build-livecd-rfs --layer oci:oci:provision-rootfs-squashfs \
      --output provision.iso
   $ # If needed, create a SUDI keypair for the VM, for instance:

--- a/live/build-livecd-rfs
+++ b/live/build-livecd-rfs
@@ -6,13 +6,15 @@
 export PATH=$PATH:.
 
 usage() {
-  echo "Example usage: --project=snakeoil:default --manifest=manifest.yaml --help"
+  echo "Example usage: --project=snakeoil:default --layer=oci:oci:provision-rootfs-squashfs --output provision.iso --help"
+  echo "               --project=snakeoil:default --layer=oci:oci:livecd-rootfs-squashfs --output livecd.iso --help"
 }
 
-short_opts="hp:m:"
-long_opts="help,project:,layer:"
+short_opts="hp:l:o:"
+long_opts="help,project:,layer:,output:"
 o=""
 LAYER=""
+OUTFILE="livecd.iso"
 project=snakeoil:default
 o=$(getopt --name "${0##*/}" --options "${short_opts}" \
 	--long "${long_opts}" -- "$@") && eval set -- "${o}" || { usage; exit 1; }
@@ -23,6 +25,7 @@ while [ $# -ne 0 ]; do
 		-h|--help) usage; exit 0;;
 		-p|--project) project="$next";;
 		-l|--layer) LAYER="$next";;
+		-o|--output) OUTFILE="$next";;
 		--) shift; break;;
 	esac
 	shift;
@@ -49,6 +52,7 @@ which zot || {
   chmod 755 zot
 }
 
+rm -rf zot-cache
 mkdir -p zot-cache
 [ -f zot-config.json ] || cat > zot-config.json << EOF
 {
@@ -124,4 +128,4 @@ mosb --debug manifest publish \
 mosb --debug mkboot --cdrom \
   snakeoil:default \
   docker://localhost:${ZOT_PORT}/machine/livecd:1.0.0 \
-  livecd.iso
+  ${OUTFILE}

--- a/live/console-helper
+++ b/live/console-helper
@@ -1,0 +1,119 @@
+#!/bin/sh
+
+getinput() {
+    local chardev="$1" out="$2" msg="$3"  b=""
+    #echo "kid $$ reporting for $chardev"
+    trap "exit 0" TERM
+    exec 3>&1
+    exec >"$chardev" <"$chardev" 2>&1 || {
+        echo "$name: failed redirect to '$chardev'" >&3
+        exit 2
+    }
+    #echo "redirected to $chardev, now reading" >&3
+    echo "$msg"
+    read b
+    [ $? -eq 0 ] || {
+        echo "$name: read failed" >&3
+        exit 1
+    }
+    echo "$$:$chardev" > "$out" || {
+        echo "$name: write to $out failed" >&3
+    }
+    exit
+}
+
+reap() {
+    local k="" kids=""
+    for k in "$@"; do
+        [ -d "/proc/$k" ] || continue
+        kids="$kids $k"
+    done
+    kids=${kids# }
+    [ -n "$kids" ] || return 0
+    #echo "reaping $kids"
+    kill -TERM $kids
+}
+
+main_sigchld() {
+    local rc=$? pid="" chardev="" line
+    [ -z "$ACTIVE_TTY" ] || return 0
+    #echo "processing sigchild: rc=$rc ($KIDS)"
+    [ -f "$tmpf" ] || { echo "no tmpf '$tmpf'"; exit 1; }
+    while read line; do
+        [ -n "$line" ] || continue
+        #echo "read line=$line"
+        pid=${line%%:*}
+        chardev=${line#*:}
+        [ -n "$chardev" ] && break
+    done < "$tmpf"
+    [ -n "$chardev" ] || return 0
+    ACTIVE_TTY=$chardev
+    #echo "found dev '$chardev' from kid=$pid: KIDS=$KIDS"
+    reap $KIDS
+    KIDS=""
+}
+
+main_sigexit() {
+    reap $KIDS
+    KIDS=""
+    [ -z "$TMPF" ] || rm -f "$TMPF"
+}
+
+main() {
+    ACTIVE_TTY=""
+    KIDS=""
+    local ttys="/dev/ttyS0 /dev/tty1"
+    trap main_sigexit TERM
+    trap main_sigexit EXIT
+    tmpf=$(mktemp) || exit 1
+    TMPF="$tmpf"
+    trap main_sigchld CHLD
+    for tty in $ttys; do
+        "$0" getinput "$tty" "$tmpf" "Press any key to continue..." &
+        KIDS="${KIDS:+${KIDS} }$!"
+    done
+    wait
+    trap "" CHLD
+    if [ -n "$ACTIVE_TTY" ]; then
+        echo "got active=$ACTIVE_TTY"
+    else
+        echo "no active found"
+        return 1
+    fi
+
+    # save/duplicate original stdout to fd 3.
+    exec 3>&2
+    # redirect output to the selected console.
+    exec >"$ACTIVE_TTY" <"$ACTIVE_TTY" 2>&1 || {
+        echo "Failed to open $ACTIVE_TTY" >&3
+        exit 1
+    }
+
+    local msg="selected '$ACTIVE_TTY' as active."
+    local curmsg="selected '$ACTIVE_TTY' (current) as active."
+    [ $# -eq 0 ] || {
+        msg="$msg executing '$1'"
+        curmsg="$curmsg executing '$1'"
+    }
+
+    # If this program's stdout is /dev/console, and user hit enter there,
+    # then we end up writing 'curmsg' o tty1 and 'msg' to /dev/console
+    # so the user will see both.  I don't know how to avoid that.
+    for tty in $ttys; do
+        [ "$tty" = "$ACTIVE_TTY" ] && continue
+        echo "$msg" >"$tty"
+    done
+    # write to program's original stdout.
+    echo "$msg" >&3
+    # write to the selected console.
+    echo "$curmsg"
+
+    [ $# -gt 0 ] || return 0
+    exec "$@"
+}
+
+case "$1" in
+    getinput) shift; getinput "$@"; exit;;
+    main) shift; main "$@"; exit;;
+esac
+main "$@"

--- a/live/provision-stacker.yaml
+++ b/live/provision-stacker.yaml
@@ -2,7 +2,7 @@ provision-base:
   build_only: true
   from:
     type: docker
-    url: "docker://zothub.io/machine/bootkit/rootfs:0.0.5.230327-squashfs"
+    url: "docker://zothub.io/machine/bootkit/rootfs:${{ROOTFS_VERSION}}"
 
 provision-rootfs-pkg:
   build_only: true

--- a/live/provision-stacker.yaml
+++ b/live/provision-stacker.yaml
@@ -50,7 +50,7 @@ provision-rootfs:
 
     cd /etc/systemd/system/
     for s in trust-provision*.service; do
-      ln -s "$PWD/$s" "/etc/systemd/system/multi-user.target.wants/$s"
+      systemctl enable ${s}
     done
     ls -ltr /etc/systemd/system/*.service
 

--- a/live/provision-stacker.yaml
+++ b/live/provision-stacker.yaml
@@ -1,0 +1,58 @@
+provision-base:
+  build_only: true
+  from:
+    type: docker
+    url: "docker://zothub.io/machine/bootkit/rootfs:0.0.5.230327-squashfs"
+
+provision-rootfs-pkg:
+  build_only: true
+  from:
+    type: built
+    tag: provision-base
+  run: |
+    pkgtool install udev kmod \
+        libsquashfs-dev tpm2-tools cryptsetup
+
+provision-rootfs:
+  from:
+    type: built
+    tag: provision-rootfs-pkg
+  import:
+    - https://github.com/project-machine/mos/releases/download/0.0.9/mosctl
+    - trust-provision
+    - trust-provision.service
+    - trust-provision-failed.service
+    - console-helper
+  run: |
+    #!/bin/sh -ex
+    writefile() {
+      mkdir -p "${1%/*}"
+      echo "write $1" 1>&2
+      cat >"$1"
+    }
+
+    writefile /etc/systemd/network/20-wire-enp0s-dhcp.network <<"END"
+    [Match]
+    Name=enp0s*
+    [Network]
+    DHCP=yes
+    END
+
+    cd /stacker
+    cp mosctl trust-provision console-helper /usr/bin
+    ( cd /usr/bin && chmod 755 mosctl trust-provision console-helper )
+
+    cp trust-provision.service trust-provision-failed.service \
+        /etc/systemd/system/
+
+    cd /
+    mkdir -p /etc/systemd/system/multi-user.target.wants
+
+    cd /etc/systemd/system/
+    for s in trust-provision*.service; do
+      ln -s "$PWD/$s" "/etc/systemd/system/multi-user.target.wants/$s"
+    done
+    ls -ltr /etc/systemd/system/*.service
+
+    systemctl enable debug-shell.service
+    systemctl mask serial-getty@ttyS0

--- a/live/stacker.yaml
+++ b/live/stacker.yaml
@@ -2,7 +2,7 @@ base:
   build_only: true
   from:
     type: docker
-    url: "docker://zothub.io/machine/bootkit/rootfs:0.0.5.230327-squashfs"
+    url: "docker://zothub.io/machine/bootkit/rootfs:${{ROOTFS_VERSION}}"
 
 rootfs-pkg:
   build_only: true

--- a/live/trust-provision
+++ b/live/trust-provision
@@ -1,0 +1,40 @@
+#!/bin/sh
+
+fail() { [ $# -eq 0 ] || echo "$@" 1>&2; exit 1; }
+
+name="${0##*/}"
+maxwait=10
+waited=0
+label="trust-data"
+devpath="/dev/disk/by-label/$label"
+
+while [ $waited -lt $maxwait ] && waited=$((waited+1)); do
+    [ -b "$devpath" ] && break
+    udevadm settle
+    [ -b "$devpath" ] && break
+    sleep .5
+done
+
+[ -b "$devpath" ] || {
+    cat<<EOF
+=========
+$0 did not find disk named $label
+========
+EOF
+fail
+}
+
+
+mp="/run/$name"
+mkdir -p "$mp" || fail "failed to mkdir $mp"
+mount "$devpath" "$mp" || fail "failed to mount $devpath to $mp"
+
+missing=""
+for f in cert.pem privkey.pem; do
+    [ -f "$mp/$f" ] || missing="$missing $f"
+done
+[ -z "$missing" ] ||
+    fail "$devpath was found, but did not contain ${missing# }"
+
+exec mosctl provision --disk /dev/sda --wipe \
+    "$mp/cert.pem" "$mp/privkey.pem"

--- a/live/trust-provision-failed.service
+++ b/live/trust-provision-failed.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Run on failure of trust-provision.
+After=getty.target multi-user.target
+Conflicts=getty@tty1.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=true
+ExecStart=/usr/bin/console-helper /bin/bash
+StandardInput=tty-force
+StandardOutput=inherit
+StandardError=inherit
+
+[Install]
+WantedBy=multi-user.target

--- a/live/trust-provision.service
+++ b/live/trust-provision.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Run the tpm stuff.
+#After=network-online.target
+After=getty.target multi-user.target local-fs.target
+Conflicts=getty@tty1.service
+OnFailure=trust-provision-failed.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=true
+ExecStart=/usr/bin/trust-provision
+StandardOutput=journal+console
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This is needed for provisioning, install, and subsequent boot.

The first commit reverts my earlier change removing the rootfs.  The trust demo livecds use that layer, so let's keep building it.