### PR TITLE
curPcr7: use /pcr7.bin if it exists

### DIFF
--- a/live/build-livecd-rfs
+++ b/live/build-livecd-rfs
@@ -65,7 +65,7 @@ mkdir -p zot-cache
     "gc": false
   },
   "http": {
-    "address": "localhost",
+    "address": "127.0.0.1",
     "port": "$ZOT_PORT"
   },
   "log": {
@@ -83,7 +83,7 @@ while [[ $count -gt 0 ]]; do
     exit 1
   fi
   up=1
-  curl -f http://localhost:$ZOT_PORT/v2/ || up=0
+  curl -f http://127.0.0.1:$ZOT_PORT/v2/ || up=0
   if [ $up -eq 1 ]; then break; fi
   sleep 1
   count=$((count - 1))
@@ -145,10 +145,10 @@ fi
 
 mosb --debug manifest publish \
   --project $project \
-  --repo localhost:${ZOT_PORT} --name machine/livecd:1.0.0 \
+  --repo 127.0.0.1:${ZOT_PORT} --name machine/livecd:1.0.0 \
   manifest.yaml
 
 mosb --debug mkboot --cdrom \
   $project \
-  docker://localhost:${ZOT_PORT}/machine/livecd:1.0.0 \
+  docker://127.0.0.1:${ZOT_PORT}/machine/livecd:1.0.0 \
   ${OUTFILE}

--- a/pkg/trust/tpm2-tools.go
+++ b/pkg/trust/tpm2-tools.go
@@ -131,7 +131,7 @@ func Tpm2NVIndexLength(nvindex NVIndex) (int, error) {
 
 	return size, nil
 }
-func (c *tpm2V3Context) Tpm2CreatePrimary() (error) {
+func (c *tpm2V3Context) Tpm2CreatePrimary() error {
 	log.Debugf("Tpm2CreatePrimary")
 	if c.Keyctx != "" {
 		log.Debugf("Tpm2CreatePrimary: a primary context already exists (%s), reusing it", c.Keyctx)
@@ -142,9 +142,9 @@ func (c *tpm2V3Context) Tpm2CreatePrimary() (error) {
 	fname := f.Name()
 	f.Close()
 
-	cmd := []string{"tpm2_createprimary", "--key-context="+fname}
+	cmd := []string{"tpm2_createprimary", "--key-context=" + fname}
 	if c.adminPwd != "" { // provisioning
-		cmd = append(cmd, optHierarchyOwner, "--hierarchy-auth=" + c.adminPwd)
+		cmd = append(cmd, optHierarchyOwner, "--hierarchy-auth="+c.adminPwd)
 	} else {
 		// reading
 		cmd = append(cmd, optHierarchyNone)
@@ -183,7 +183,6 @@ func (c *tpm2V3Context) Tpm2StartSession(isTrial TrialPolicy) error {
 
 	return run(cmd...)
 }
-
 
 func (c *tpm2V3Context) Tpm2PolicyPCR(pcrs string) error {
 	return run("tpm2_policypcr", "--session="+c.sessionFile, "--pcr-list="+pcrs)
@@ -303,6 +302,7 @@ func Tpm2Clear() error {
 	}
 	return nil
 }
+
 // Write a value which is publically readable but only writeable with tpm admin pass
 func (c *tpm2V3Context) StorePublic(idx NVIndex, value string) error {
 	attributes := "ownerwrite|ownerread|authread"

--- a/pkg/trust/tpm2-tools.go
+++ b/pkg/trust/tpm2-tools.go
@@ -29,6 +29,8 @@ const (
 	TrialSession              = true
 )
 
+const RootfsPCRFile = "/pcr7.bin"
+
 func readHostPcr7() ([]byte, error) {
 	f, err := ioutil.TempFile("/tmp", "pcr")
 	if err != nil {
@@ -48,7 +50,13 @@ func readHostPcr7() ([]byte, error) {
 }
 
 func curPcr7() (string, error) {
-	c, err := readHostPcr7()
+	var c []byte
+	var err error
+	if PathExists(RootfsPCRFile) {
+		c, err = ioutil.ReadFile(RootfsPCRFile)
+	} else {
+		c, err = readHostPcr7()
+	}
 	if err != nil {
 		return "", fmt.Errorf("Error reading host pcr7: %w", err)
 	}


### PR DESCRIPTION
If /pcr7.bin exists, then initrd wrote it there before extending
pcr7, so use that.
