### PR TITLE
build-livecd-rfs: Do not add '.' to PATH, but instead $PWD

### DIFF
--- a/live/build-livecd-rfs
+++ b/live/build-livecd-rfs
@@ -3,7 +3,7 @@
 # This script is long enough and a common enough operation that it
 # suggests we should have a mosb subcommand for this.
 
-export PATH=$PATH:.
+export PATH="$PATH:$PWD"
 
 usage() {
   echo "Example usage: --project=snakeoil:default --layer=oci:oci:provision-rootfs-squashfs --output provision.iso --help"


### PR DESCRIPTION
Golang now refuses to execute a program if it is found in '.'. It will return the ErrDot error.

This change just adds the full directory path to the current directory instead.