### PR TITLE
Update the live/README and provisioning-stacker.yaml

### DIFF
--- a/live/README.md
+++ b/live/README.md
@@ -1,5 +1,6 @@
 # Building live cd
 
+ * Ensure you have installed all of the build requirements for mos, trust, and bootkit.  (See the .github/workflows/build.yml files in each)
  * Create bootkit artifacts under .local/share/machine/trust/keys/$keyset - should
    be done by 'trust keyset add'
 
@@ -7,17 +8,24 @@
    git clone https://github.com/hallyn/bootkit
    cd bootkit
    make build
-   umoci unpack --image ../build-bootkit/oci:bootkit \
+   umoci unpack --rootless --image \
+       ../build-bootkit/oci:bootkit xxx
+   mv xxx/rootfs/bootkit
       ~/.local/share/machine/trust/keys/snakeoil/
+   rm -rf xxx
    ```
    NOTE - we want to move that from the project into the keyset.
 
+ * pin rootfs version to use
+   ```
+   export ROOTFS_VERSION=0.0.5.230327-squashfs
+   ```
  * cd live
  * build the rootfs
  
     ```
     stacker build --layer-type=squashfs \
-      --substitute ROOTFS_VERSION=0.0.5.230327-squashfs
+      --substitute ROOTFS_VERSION="${ROOTFS_VERSION}"
     ```
 
    * Note: I  seem to be hitting a bug with this, where it fails to build the second time.

--- a/live/provision-stacker.yaml
+++ b/live/provision-stacker.yaml
@@ -18,7 +18,7 @@ provision-rootfs:
     type: built
     tag: provision-rootfs-pkg
   import:
-    - https://github.com/project-machine/mos/releases/download/0.0.9/mosctl
+    - https://github.com/project-machine/mos/releases/download/0.0.11/mosctl
     - trust-provision
     - trust-provision.service
     - trust-provision-failed.service


### PR DESCRIPTION
Closes #48

Add a few missing instructions.
Make sure the ROOTFS_VERSION is set.
Download a newer mosctl binary.