### PR TITLE
Use : after manifest key to select a specific project manifest to show

### DIFF
--- a/cmd/trust/keyset.go
+++ b/cmd/trust/keyset.go
@@ -54,12 +54,12 @@ func generateMosCreds(keysetPath string, ctemplate *x509.Certificate) error {
 		doguid bool
 	}
 	keyinfo := map[string]AddCertInfo{
-		"tpmpol-admin":   AddCertInfo{"TPM EAPolicy Admin", false},
-		"tpmpol-luks":    AddCertInfo{"TPM EAPolicy LUKS", false},
-		"uki-tpm":        AddCertInfo{"UKI TPM", true},
-		"uki-limited":    AddCertInfo{"UKI Limited", true},
-		"uki-production": AddCertInfo{"UKI Production", true},
-		"uefi-db":        AddCertInfo{"UEFI DB", true},
+		"tpmpol-admin":   {"TPM EAPolicy Admin", false},
+		"tpmpol-luks":    {"TPM EAPolicy LUKS", false},
+		"uki-tpm":        {"UKI TPM", true},
+		"uki-limited":    {"UKI Limited", true},
+		"uki-production": {"UKI Production", true},
+		"uefi-db":        {"UEFI DB", true},
 	}
 
 	for key, CertInfo := range keyinfo {
@@ -219,11 +219,11 @@ func initkeyset(keysetName string, Org []string) error {
 
 	// Add the signdata to the keyset
 	p := pcr7Data{
-			limited: limitedPcr,
-			tpm: tpmPcr,
-			production: prodPcr,
-			passwdPolicyDigest: tpmpasswdPolicyDigest,
-			luksPolicyDigest: luksPolicyDigest}
+		limited:            limitedPcr,
+		tpm:                tpmPcr,
+		production:         prodPcr,
+		passwdPolicyDigest: tpmpasswdPolicyDigest,
+		luksPolicyDigest:   luksPolicyDigest}
 
 	if err = addPcr7data(keysetName, p); err != nil {
 		return fmt.Errorf("Failed to add the pcr7data to keyset %q: (%w)", keysetName, err)
@@ -236,12 +236,12 @@ var keysetCmd = cli.Command{
 	Name:  "keyset",
 	Usage: "Administer keysets for mos",
 	Subcommands: []cli.Command{
-		cli.Command{
+		{
 			Name:   "list",
 			Action: doListKeysets,
 			Usage:  "list keysets",
 		},
-		cli.Command{
+		{
 			Name:      "add",
 			Action:    doAddKeyset,
 			Usage:     "add a new keyset",
@@ -253,7 +253,7 @@ var keysetCmd = cli.Command{
 				},
 			},
 		},
-		cli.Command{
+		{
 			Name:      "show",
 			Action:    doShowKeyset,
 			Usage:     "show keyset key values or paths",
@@ -269,31 +269,31 @@ var keysetCmd = cli.Command{
 				},
 			},
 		},
-		cli.Command{
-			Name:		"pcr7data",
-			Action:		doAddPCR7data,
-			Usage:		"include the specified pcr7data into keyset",
-			ArgsUsage:	"<keyset-name>",
+		{
+			Name:      "pcr7data",
+			Action:    doAddPCR7data,
+			Usage:     "include the specified pcr7data into keyset",
+			ArgsUsage: "<keyset-name>",
 			Flags: []cli.Flag{
 				cli.StringFlag{
-					Name: "pcr7-tpm",
+					Name:  "pcr7-tpm",
 					Usage: "Pathname to the pcr7 tpm binary file",
 				},
 				cli.StringFlag{
-					Name: "pcr7-limited",
+					Name:  "pcr7-limited",
 					Usage: "Pathname to the pcr7 limited binary file",
 				},
 				cli.StringFlag{
-					Name: "pcr7-prod",
+					Name:  "pcr7-prod",
 					Usage: "Pathname to the pcr7 production binary file",
 				},
 				cli.StringFlag{
-					Name: "passwdPolicy",
+					Name:  "passwdPolicy",
 					Usage: "Pathname to the tpm passwd policy file (optional)",
 					Value: "passwd_policy.out",
 				},
 				cli.StringFlag{
-					Name: "luksPolicy",
+					Name:  "luksPolicy",
 					Usage: "Pathname to the luks policy file (optional)",
 					Value: "luks_policy.out",
 				},
@@ -512,11 +512,11 @@ func doAddPCR7data(ctx *cli.Context) error {
 	}
 
 	p := pcr7Data{
-			limited:            limitedPCR7,
-			tpm:                tpmPCR7,
-			production:         prodPCR7,
-			passwdPolicyDigest: passwdPD,
-			luksPolicyDigest:   luksPD}
+		limited:            limitedPCR7,
+		tpm:                tpmPCR7,
+		production:         prodPCR7,
+		passwdPolicyDigest: passwdPD,
+		luksPolicyDigest:   luksPD}
 
 	if err := addPcr7data(keysetName, p); err != nil {
 		return err

--- a/cmd/trust/keyset.go
+++ b/cmd/trust/keyset.go
@@ -45,6 +45,9 @@ func isValidKeyDir(keydir string) bool {
 			return true
 		}
 	}
+	if strings.HasPrefix(keydir, "manifest:") {
+		return true
+	}
 	return false
 }
 
@@ -406,6 +409,15 @@ func doShowKeyset(ctx *cli.Context) error {
 
 	if !isValidKeyDir(keyName) {
 		return fmt.Errorf("Invalid keyset key name '%s':, must be one of: %s", strings.Join(KeysetKeyDirs, ", "))
+	}
+
+	// manifest requires a project name
+	if keyName == "manifest" {
+		return fmt.Errorf("keyset key 'manifest' requires a project value, use 'trust project list %s' to list projects for this keyset", keysetName)
+	}
+
+	if strings.HasPrefix(keyName, "manifest:") {
+		keyName = strings.Replace(keyName, ":", "/", 1)
 	}
 
 	keyPath := filepath.Join(keysetPath, keyName)


### PR DESCRIPTION
Allow the keydir 'manifest' to accept a project value after a colon:

```
$ ./trust keyset show snakeoil manifest
2023/08/18 15:18:23 fatal keyset key 'manifest' requires a project value, use 'trust project list snakeoil' to list projects for this keyset
$ ./trust keyset show snakeoil manifest:default --path
/home/ubuntu/.local/share/machine/trust/keys/snakeoil/manifest/default/cert.pem
/home/ubuntu/.local/share/machine/trust/keys/snakeoil/manifest/default/privkey.pem
/home/ubuntu/.local/share/machine/trust/keys/snakeoil/manifest/default/uuid
```

Fixes: #59

Signed-off-by: Ryan Harper <rharper@woxford.com>
