### PR TITLE
bump bootkit layer version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,10 +5,13 @@ ifeq ($(MAIN_VERSION),$(filter $(MAIN_VERSION), "", no-git))
 $(error "Bad value for MAIN_VERSION: '$(MAIN_VERSION)'")
 endif
 
+BOOTKIT_VERSION ?= "v0.0.10.230825"
+
 GO_SRC_DIRS := pkg/ cmd/
 GO_SRC := $(shell find $(GO_SRC_DIRS) -name "*.go")
 
-VERSION_LDFLAGS=-X github.com/project-machine/trust/pkg/trust.Version=$(MAIN_VERSION)
+VERSION_LDFLAGS=-X github.com/project-machine/trust/pkg/trust.Version=$(MAIN_VERSION) \
+	-X github.com/project-machine/trust/pkg/trust.BootkitVersion=$(BOOTKIT_VERSION)
 trust: .made-gofmt $(GO_SRC)
 	go build -buildvcs=false -ldflags "$(VERSION_LDFLAGS)" -o trust ./cmd/trust/
 

--- a/cmd/trust/keyset.go
+++ b/cmd/trust/keyset.go
@@ -253,6 +253,11 @@ var keysetCmd = cli.Command{
 					Name:  "org, Org, organization",
 					Usage: "X509-Organization field to add to certificates when generating a new keyset. (optional)",
 				},
+				cli.StringFlag{
+					Name:  "bootkit-version",
+					Usage: "Version of bootkit artifacts to use",
+					Value: trust.BootkitVersion,
+				},
 			},
 		},
 		{
@@ -315,6 +320,7 @@ func doAddKeyset(ctx *cli.Context) error {
 		return errors.New("Please specify keyset name")
 	}
 
+	bootkitVersion := ctx.String("bootkit-version")
 	Org := ctx.StringSlice("org")
 	if Org == nil {
 		log.Infof("X509-Organization field for new certificates not specified.")
@@ -346,7 +352,7 @@ func doAddKeyset(ctx *cli.Context) error {
 	}
 
 	// Now create the bootkit artifacts
-	if err = trust.SetupBootkit(keysetName); err != nil {
+	if err = trust.SetupBootkit(keysetName, bootkitVersion); err != nil {
 		return fmt.Errorf("Failed creating bootkit artifacts for keyset %q: (%w)", keysetName, err)
 	}
 

--- a/pkg/trust/artifacts.go
+++ b/pkg/trust/artifacts.go
@@ -163,7 +163,7 @@ func UpdateShim(inShim, newShim, keysetPath string) error {
 	return nil
 }
 
-func SetupBootkit(keysetName string) error {
+func SetupBootkit(keysetName, bootkitVersion string) error {
 	// TODO - we have to fix this by
 	// a. having bootkit generate arm64
 	// b. changing the bootkit layer naming to reflect arch
@@ -185,7 +185,7 @@ func SetupBootkit(keysetName string) error {
 		return errors.Wrapf(err, "couldn't find home dir")
 	}
 	ociDir := filepath.Join(home, ".cache", "machine", "trust", "bootkit", "oci")
-	bootkitLayer := "bootkit:0.0.5.230327-squashfs"
+	bootkitLayer := "bootkit:" + bootkitVersion + "-squashfs"
 	EnsureDir(ociDir)
 	cachedOci := fmt.Sprintf("oci:%s:%s", ociDir, bootkitLayer)
 	err = lib.ImageCopy(lib.ImageCopyOpts{

--- a/pkg/trust/const.go
+++ b/pkg/trust/const.go
@@ -57,3 +57,4 @@ var SBFPartitionTypeID = [16]byte{
 const MiB, GiB = uint64(1024 * 1024), uint64(1024 * 1024 * 1024)
 
 var Version string
+var BootkitVersion string


### PR DESCRIPTION
artifacts.go is fetching a bootkit layer to update the artifacts.

Move the definition of it to Makefile, and allow the caller to specify it.

This is still not how it should be - trust should use the bootkit api.  But then it should still allow the user to specify the version.