### PR TITLE
Compare keysetName to "snakeoil", not to itself

### DIFF
--- a/cmd/trust/keyset.go
+++ b/cmd/trust/keyset.go
@@ -338,7 +338,7 @@ func doAddKeyset(ctx *cli.Context) error {
 	}
 
 	switch keysetName {
-	case keysetName:
+	case "snakeoil":
 		// git clone if keyset is snakeoil
 		_, err = git.PlainClone(keysetPath, false, &git.CloneOptions{URL: "https://github.com/project-machine/keys.git"})
 


### PR DESCRIPTION
All keysets were being created with the snakeoil pcr7data because a switch was comparing keysetName to itself.